### PR TITLE
1.2 Test Suite Input Conformance Classes

### DIFF
--- a/src/main/scripts/ctl/gpkg12-suite.ctl
+++ b/src/main/scripts/ctl/gpkg12-suite.ctl
@@ -76,7 +76,7 @@
               </xsl:otherwise>
             </xsl:choose>
           </entry>
-          <entry key="ics">Core,Tiles,Features,Extensions,Non-linear Geometries,RTree Index,Webp,Metadata,Schema,CRS WKT,Tiled Gridded Elevation Data</entry>
+          <entry key="ics">Core,Tiles,Features,Attributes,Extensions,Non-linear Geometries,RTree Index,Webp,Metadata,Schema,CRS WKT</entry>
 		    </properties>
 		   </xsl:variable>
        <xsl:variable name="testRunDir">

--- a/src/main/scripts/ctl/gpkg12-suite.ctl
+++ b/src/main/scripts/ctl/gpkg12-suite.ctl
@@ -76,7 +76,7 @@
               </xsl:otherwise>
             </xsl:choose>
           </entry>
-          <entry key="ics">Core,Tiles,Features,Attributes,Extensions,Non-linear Geometries,RTree Index,Webp,Metadata,Schema,CRS WKT</entry>
+          <entry key="ics">Core,Tiles,Features,Attributes,Extensions,Non-linear Geometries,RTree Index,Webp,Metadata,Schema,CRS WKT,Tiled Gridded Elevation Data</entry>
 		    </properties>
 		   </xsl:variable>
        <xsl:variable name="testRunDir">


### PR DESCRIPTION
For the http://cite.opengeospatial.org/te2/ gpkg12 test suite:
* Add `Attributes` as an input conformance class
* Remove `Tiled Gridded Elevation Data` from being tested as [it was removed from the spec](http://www.geopackage.org/spec120/#extension_tiled_gridded_elevation_data) and will be rewritten as Tiled Gridded Coverage Data in the next release.