### PR TITLE
Upgrade ets-common and maven-fluido-skin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opengis.cite</groupId>
     <artifactId>ets-common</artifactId>
-    <version>13</version>
+    <version>14</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>ets-gpkg12</artifactId>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -7,7 +7,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.5</version>
+    <version>2.0.1</version>
   </skin>
   <custom>
     <fluidoSkin>


### PR DESCRIPTION
Upgrading `maven-fluido-skin` to version 2.0.1 (site.xml) while using `ets-common` version 13 (pom.xml) caused the maven build to fail. The issue arises because `Doxia Sitetools` requires version 2.0.0, but `ets-common` version 13 provides only 1.11.1. It was fixed by upgrading to  `ets-common` version 14 , since it uses `Doxia Sitetools` version 2.0.0.